### PR TITLE
Force upgrade of pip and install of setuptools and wheel at venv-create

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,15 @@ results in
 
 ```
 
+(data-science) $ pip install --upgrade pip setuptools wheel
+
 # Created virtual environment data-science
 
 # To activate it run:
 
 venv-activate data-science
 
-# Then upgrade pip and friends:
-
-pip install --upgrade pip setuptools wheel
-
-# To exit the virutal environment run:
+# To exit the virtual environment run:
 
 deactivate
 

--- a/_venv-activate.sh
+++ b/_venv-activate.sh
@@ -16,10 +16,13 @@ function venv-create() {
         printf "\nEnter a new virtual environment name\n\n"
     else
         "${VENV_ACTIVATE_PYTHON}" -m venv "${HOME}/venvs/$1"
+        . "${HOME}/venvs/$1/bin/activate"
+        printf "\n(%s) $ pip install --upgrade pip setuptools wheel\n" "${1}"
+        pip install --upgrade --quiet pip setuptools wheel
+        deactivate
         printf "\n# Created virtual environment %s\n" "${1}"
         printf "\n# To activate it run:\n\nvenv-activate %s\n" "${1}"
-        printf "\n# Then upgrade pip and friends:\n\npip install --upgrade pip setuptools wheel\n"
-        printf "\n# To exit the virutal environment run:\n\ndeactivate\n\n"
+        printf "\n# To exit the virtual environment run:\n\ndeactivate\n\n"
         return 0
     fi
     return 1


### PR DESCRIPTION
As Michael Kennedy [has pointed out](https://gitter.im/talk-python/Lobby?at=5d9d24db49c7720aaf8cd6e7) there is no reason to not upgrade pip and friends during venv creation. This forces the venv to do so.