### PR TITLE
Add venv-remove functionality

### DIFF
--- a/_venv-activate.sh
+++ b/_venv-activate.sh
@@ -72,5 +72,29 @@ function venv-activate() {
     return 1
 }
 
+function venv-remove() {
+    function display_venvs {
+        $(which ls) -1 "${VENV_ACTIVATE_HOME}/" | sed 's/^/* /'
+    }
+    if [[ ! -d "${VENV_ACTIVATE_HOME}" ]]; then
+        printf "\n# ERROR: venv-remove fails as VENV_ACTIVATE_HOME does not exist.\n\n"
+        return 1
+    fi
+    if [[ -z "$1" ]]; then
+        printf "\nEnter a virtual environment name to remove\n\n"
+        display_venvs
+    elif [[ ! -d "${VENV_ACTIVATE_HOME}/$1" ]]; then
+        printf "\nERROR: %s does not exist as a virtual environment under ${VENV_ACTIVATE_HOME}/\n" "${1}"
+        printf "\nEnter an existing virtual environment name to remove:\n"
+        display_venvs
+    else
+        rm -rf "${VENV_ACTIVATE_HOME:?}/${1}"
+        printf "\n# Deleted virtual environment %s\n" "${1}"
+        return 0
+    fi
+    return 1
+}
+
 complete venv-create
 complete -F _venv-activate venv-activate
+complete -F _venv-activate venv-remove


### PR DESCRIPTION
Add ability to remove virtual environments with function called 'venv-remove'.

Full environment lifecycle example:
```
$ venv-create test

(test) $ pip install --upgrade pip setuptools wheel

# Created virtual environment test

# To activate it run:

venv-activate test

# To exit the virtual environment run:

deactivate

$ venv-activate test 
(test) $ pip list
Package       Version
------------- -------
pip           19.3.1 
pkg-resources 0.0.0  
setuptools    42.0.2 
wheel         0.33.6 
(test) $ deactivate 
$ venv-remove test 

# Deleted virtual environment test
```