### PR TITLE
Use python -m pip to advocate for best pip practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ results in
 
 ```
 
-(data-science) $ pip install --upgrade pip setuptools wheel
+(data-science) $ python -m pip install --upgrade pip setuptools wheel
 
 # Created virtual environment data-science
 

--- a/_venv-activate.sh
+++ b/_venv-activate.sh
@@ -31,8 +31,8 @@ function venv-create() {
         "${VENV_ACTIVATE_PYTHON}" -m venv "${VENV_ACTIVATE_HOME}/${1}"
         # shellcheck disable=SC1090
         . "${VENV_ACTIVATE_HOME}/$1/bin/activate"
-        printf "\n(%s) $ pip install --upgrade pip setuptools wheel\n" "${1}"
-        pip install --upgrade --quiet pip setuptools wheel
+        printf "\n(%s) $ python -m pip install --upgrade pip setuptools wheel\n" "${1}"
+        python -m pip install --upgrade --quiet pip setuptools wheel
         deactivate
         printf "\n# Created virtual environment %s\n" "${1}"
         printf "\n# To activate it run:\n\nvenv-activate %s\n" "${1}"


### PR DESCRIPTION
Be very explicit with the user about what is being run and even though it isn't necessary, use `python -m pip` to advocate for best pip practices.

```
$ venv-create test

(test) $ python -m pip install --upgrade pip setuptools wheel

# Created virtual environment test

# To activate it run:

venv-activate test

# To exit the virtual environment run:

deactivate

$ venv-activate test 
(test) $ pip list
Package       Version
------------- -------
pip           18.1   
pkg-resources 0.0.0  
setuptools    40.8.0 
(test) $ deactivate 
(test) $ venv-remove test 

# Deleted virtual environment test
```