### PR TITLE
Preface global shell variables with underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ If `_venv-activate.sh` is installed at `/opt/_venv-activate/_venv-activate.sh` t
 ```
 # Enable tab completion of Python virtual environments
 if [ -f /opt/_venv-activate/_venv-activate.sh ]; then
-    VENV_ACTIVATE_HOME="${HOME}/.venvs"
-    VENV_ACTIVATE_PYTHON=$(which python3)
+    _VENV_ACTIVATE_HOME="${HOME}/.venvs"
+    _VENV_ACTIVATE_PYTHON=$(which python3)
     . /opt/_venv-activate/_venv-activate.sh
 fi
 ```

--- a/_venv-activate.sh
+++ b/_venv-activate.sh
@@ -1,36 +1,36 @@
 #!/usr/bin/env bash
 
-if [[ -z "${VENV_ACTIVATE_HOME}" ]]; then
-    printf "\n# ERROR: venv-activate fails as VENV_ACTIVATE_HOME is not set.\n"
+if [[ -z "${_VENV_ACTIVATE_HOME}" ]]; then
+    printf "\n# ERROR: venv-activate fails as _VENV_ACTIVATE_HOME is not set.\n"
     _check_flag=1
 fi
-if [[ -z "${VENV_ACTIVATE_PYTHON}" ]]; then
-    printf "\n# ERROR: venv-activate fails as VENV_ACTIVATE_PYTHON is not set.\n"
+if [[ -z "${_VENV_ACTIVATE_PYTHON}" ]]; then
+    printf "\n# ERROR: venv-activate fails as _VENV_ACTIVATE_PYTHON is not set.\n"
     _check_flag=1
 fi
 if [[ "${_check_flag}" -eq 1 ]]; then
     unset _check_flag
     return 1
 fi
-if [[ ! -d "${VENV_ACTIVATE_HOME}" ]]; then
-    printf "\n# ERROR: venv-venv-activate fails as VENV_ACTIVATE_HOME path %s does not exist.\n\n" "${VENV_ACTIVATE_HOME}"
+if [[ ! -d "${_VENV_ACTIVATE_HOME}" ]]; then
+    printf "\n# ERROR: venv-venv-activate fails as _VENV_ACTIVATE_HOME path %s does not exist.\n\n" "${_VENV_ACTIVATE_HOME}"
     return 1
 fi
 
 function venv-create() {
-    if [[ ! -d "${VENV_ACTIVATE_HOME}" ]]; then
-        printf "\n# ERROR: venv-create fails as VENV_ACTIVATE_HOME does not exist.\n\n"
+    if [[ ! -d "${_VENV_ACTIVATE_HOME}" ]]; then
+        printf "\n# ERROR: venv-create fails as _VENV_ACTIVATE_HOME does not exist.\n\n"
         return 1
     fi
     if [[ -z "$1" ]]; then
         printf "\nEnter a new virtual environment name\n\n"
-    elif [[ -d "${VENV_ACTIVATE_HOME}/$1" ]]; then
-        printf "\nERROR: %s already exists as a virtual environment: ${VENV_ACTIVATE_HOME}/%s\n" "${1}" "${1}"
+    elif [[ -d "${_VENV_ACTIVATE_HOME}/$1" ]]; then
+        printf "\nERROR: %s already exists as a virtual environment: ${_VENV_ACTIVATE_HOME}/%s\n" "${1}" "${1}"
         printf "\nEnter a new virtual environment name\n\n"
     else
-        "${VENV_ACTIVATE_PYTHON}" -m venv "${VENV_ACTIVATE_HOME}/${1}"
+        "${_VENV_ACTIVATE_PYTHON}" -m venv "${_VENV_ACTIVATE_HOME}/${1}"
         # shellcheck disable=SC1090
-        . "${VENV_ACTIVATE_HOME}/$1/bin/activate"
+        . "${_VENV_ACTIVATE_HOME}/$1/bin/activate"
         printf "\n(%s) $ python -m pip install --upgrade pip setuptools wheel\n" "${1}"
         python -m pip install --upgrade --quiet pip setuptools wheel
         deactivate
@@ -47,7 +47,7 @@ _venv-activate()
     local cur opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    opts="$(command ls -1 "${VENV_ACTIVATE_HOME}/" | sed 's/^//')"
+    opts="$(command ls -1 "${_VENV_ACTIVATE_HOME}/" | sed 's/^//')"
 
     if [[ ${cur} == * ]] ; then
         COMPREPLY=($(compgen -W "${opts}" "${cur}"))
@@ -57,14 +57,14 @@ _venv-activate()
 
 function venv-activate() {
     function display_venvs {
-        command ls -1 "${VENV_ACTIVATE_HOME}/" | sed 's/^/* /'
+        command ls -1 "${_VENV_ACTIVATE_HOME}/" | sed 's/^/* /'
     }
     if [[ -z "$1" ]]; then
         printf "\nEnter a virtual environment:\n"
         display_venvs
-    elif [[ -d "${VENV_ACTIVATE_HOME}/$1" ]]; then
+    elif [[ -d "${_VENV_ACTIVATE_HOME}/$1" ]]; then
         # shellcheck disable=SC1090
-        source "${VENV_ACTIVATE_HOME}/$1/bin/activate"
+        source "${_VENV_ACTIVATE_HOME}/$1/bin/activate"
         return 0
     else
         printf "\n%s is not a valid virtual environment." "${1}"
@@ -76,21 +76,21 @@ function venv-activate() {
 
 function venv-remove() {
     function display_venvs {
-        command ls -1 "${VENV_ACTIVATE_HOME}/" | sed 's/^/* /'
+        command ls -1 "${_VENV_ACTIVATE_HOME}/" | sed 's/^/* /'
     }
-    if [[ ! -d "${VENV_ACTIVATE_HOME}" ]]; then
-        printf "\n# ERROR: venv-remove fails as VENV_ACTIVATE_HOME does not exist.\n\n"
+    if [[ ! -d "${_VENV_ACTIVATE_HOME}" ]]; then
+        printf "\n# ERROR: venv-remove fails as _VENV_ACTIVATE_HOME does not exist.\n\n"
         return 1
     fi
     if [[ -z "$1" ]]; then
         printf "\nEnter a virtual environment name to remove\n\n"
         display_venvs
-    elif [[ ! -d "${VENV_ACTIVATE_HOME}/$1" ]]; then
-        printf "\nERROR: %s does not exist as a virtual environment under ${VENV_ACTIVATE_HOME}/\n" "${1}"
+    elif [[ ! -d "${_VENV_ACTIVATE_HOME}/$1" ]]; then
+        printf "\nERROR: %s does not exist as a virtual environment under ${_VENV_ACTIVATE_HOME}/\n" "${1}"
         printf "\nEnter an existing virtual environment name to remove:\n"
         display_venvs
     else
-        rm -rf "${VENV_ACTIVATE_HOME:?}/${1}"
+        rm -rf "${_VENV_ACTIVATE_HOME:?}/${1}"
         printf "\n# Deleted virtual environment %s\n" "${1}"
         return 0
     fi


### PR DESCRIPTION
This makes tab completion friendlier for `zsh` users. Otherwise, when they try to tab complete on the `venv-activate` commands they will also get `VENV_ACTIVATE_HOME` and `VENV_ACTIVATE_PYTHON` as options.