### PR TITLE
Add venv-info to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,60 @@ and tab completing `data-science` and hitting `enter` then activates the virtual
 (data-science) $
 ```
 
+## API
+
+### `venv-create`
+
+Create a new Python virtual environment.
+
+```
+$ venv-create sandbox
+
+(sandbox) $ python -m pip install --upgrade pip setuptools wheel
+
+# Created virtual environment sandbox
+
+# To activate it run:
+
+venv-activate sandbox
+
+# To exit the virtual environment run:
+
+deactivate
+
+```
+
+### `venv-activate`
+
+Activate an existing Python virtual environment.
+
+```
+$ venv-activate sandbox
+(sandbox) $
+```
+
+### `venv-remove`
+
+Remove an existing Python virtual environment by deleting the `venv` directory (which holds the Python runtime and installed packages).
+
+```
+$ venv-remove sandbox
+
+# Deleted virtual environment sandbox
+```
+
+### `venv-info`
+
+Show version information for Python and pip, and how many packages are installed inside the Python virtual environment.
+
+```
+$ venv-info sandbox
+
+# Python   : v3.7.5
+# pip      : v19.3.1
+# installed: 1 packages
+```
+
 ## Authors
 
 Primary Author: [Matthew Feickert](http://www.matthewfeickert.com/)

--- a/_venv-activate.sh
+++ b/_venv-activate.sh
@@ -97,6 +97,32 @@ function venv-remove() {
     return 1
 }
 
+function venv-info() {
+    function display_venvs {
+        command ls -1 "${_VENV_ACTIVATE_HOME}/" | sed 's/^/* /'
+    }
+    if [[ ! -d "${_VENV_ACTIVATE_HOME}" ]]; then
+        printf "\n# ERROR: venv-info fails as _VENV_ACTIVATE_HOME does not exist.\n\n"
+        return 1
+    fi
+    if [[ -z "$1" ]]; then
+        printf "\nEnter a virtual environment name to show information:\n\n"
+        display_venvs
+    elif [[ ! -d "${_VENV_ACTIVATE_HOME}/$1" ]]; then
+        printf "\nERROR: %s does not exist as a virtual environment under ${_VENV_ACTIVATE_HOME}/\n" "${1}"
+        printf "\nEnter an existing virtual environment name to show information:\n"
+        display_venvs
+    else
+        local venv_bin="${_VENV_ACTIVATE_HOME:?}/${1}/bin"
+        printf "\n# Python   : v%s\n" "$(${venv_bin}/python --version | awk '{print $NF}')"
+        printf "# pip      : v%s\n" "$(${venv_bin}/python -m pip --version | awk '{print $2}')"
+        printf "# installed: %s\n" "$(${venv_bin}/python -m pip freeze | wc -l) packages"
+        return 0
+    fi
+    return 1
+}
+
 complete venv-create
 complete -F _venv-activate venv-activate
 complete -F _venv-activate venv-remove
+complete -F _venv-activate venv-info


### PR DESCRIPTION
Add `venv-info` to API and add API to README with examples.

```
$ venv-info sandbox

# Python   : v3.7.5
# pip      : v19.3.1
# installed: 1 packages
```